### PR TITLE
fix chown syntax

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,7 @@ ensure_mod() {
     G_ID="${4}"
 
     chmod "${MOD}" "${FILE}"
-    chown "${U_ID}"."${G_ID}" "${FILE}"
+    chown "${U_ID}":"${G_ID}" "${FILE}"
 }
 
 generate_passwd() {


### PR DESCRIPTION
chown command should use `:` instead of a single dot to separate user and group

Possibly fixes #14 